### PR TITLE
ESD-1228: [patch] autolink jira duplication fix

### DIFF
--- a/.github/workflows/autolink_jira.yaml
+++ b/.github/workflows/autolink_jira.yaml
@@ -13,7 +13,7 @@ jobs:
   autolink:
     name: Add Jira Link to PR Title/Description
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.title, '[A-Za-z\d-_.\\/]+') }}
     steps:
       - uses: tzkhan/pr-update-action@v2
         with:


### PR DESCRIPTION
Jira issue: [ESD-1228](https://medibank.atlassian.net/browse/ESD-1228)
---

#### What does this PR do?

Fixes a bug where the jira ticket is linked twice on consecutive PR events

[ESD-1228]: https://medibank.atlassian.net/browse/ESD-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ