### PR TITLE
ESD-1228: [patch] Attempts to fix the duplication of the jira url

### DIFF
--- a/.github/workflows/autolink_jira.yaml
+++ b/.github/workflows/autolink_jira.yaml
@@ -13,7 +13,7 @@ jobs:
   autolink:
     name: Add Jira Link to PR Title/Description
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' && !startsWith(github.event.pull_request.title, '([A-Za-z]{2,3})-(\d{1,5})') }}
+    if: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.title, '([A-Za-z]{2,3}-\\d{1,5})') }}
 
     steps:
       - uses: tzkhan/pr-update-action@v2


### PR DESCRIPTION
Jira issue: [ESD-1228](https://medibank.atlassian.net/browse/ESD-1228)
---

This pull request includes a small change to the `.github/workflows/autolink_jira.yaml` file. The change modifies the condition for the `autolink` job to use the `contains` function instead of `startsWith` for checking the Jira ticket format in the pull request title.

[ESD-1228]: https://medibank.atlassian.net/browse/ESD-1228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ