### PR TITLE
SF-0: fix(autolink_jira): prevent Jira autolink double up

### DIFF
--- a/.github/workflows/autolink_jira.yaml
+++ b/.github/workflows/autolink_jira.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   autolink:
     name: Add Jira Link to PR Title and Description
-    if: ${{ github.event_name == 'pull_request' }}
+    if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.body || '', 'Jira ticket: ') }}"
     runs-on: ubuntu-latest
     steps:
       - uses: tzkhan/pr-update-action@v2


### PR DESCRIPTION
Jira ticket: [SF-0](https://medibank.atlassian.net/browse/SF-0)
---

Prevent doubling up at the top of PR description:
<img width="574" height="175" alt="image" src="https://github.com/user-attachments/assets/c27eac3c-3b47-4cb2-9368-7d3ac70bcf74" />
