### PR TITLE
AS-924: feat(workflows): use SHA instead of version on external workflows

### DIFF
--- a/.github/workflows/autolink-jira.yaml
+++ b/.github/workflows/autolink-jira.yaml
@@ -14,11 +14,12 @@ jobs:
     if: "${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.body || '', 'Jira ticket: ') }}"
     runs-on: ubuntu-latest
     steps:
-      - uses: tzkhan/pr-update-action@v2
+      # Release 2.0.0
+      - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           head-branch-regex: '([A-Za-z]{2,4})-(\d{1,5})'
-          title-template: "%headbranch%: "
+          title-template: '%headbranch%: '
           title-update-action: prefix
           body-template: |
             Jira ticket: [%headbranch%](https://medibank.atlassian.net/browse/%headbranch%)

--- a/.github/workflows/validate-pr-conventions.yml
+++ b/.github/workflows/validate-pr-conventions.yml
@@ -19,7 +19,8 @@ jobs:
       DOCS_LINK: 'https://medibank.atlassian.net/wiki/spaces/AHM/pages/1969062105/Commits+-+Conventional+Commits'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        # Release 6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Jira ticket: [AS-924](https://medibank.atlassian.net/browse/AS-924)
---

This PR updates all external workflows to use their SHA instead of a tag or version number.

[AS-924]: https://medibank.atlassian.net/browse/AS-924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ