### PR TITLE
Revert "AS-924: feat(workflows): use SHA instead of version on external workflows"

### DIFF
--- a/.github/workflows/autolink-jira.yaml
+++ b/.github/workflows/autolink-jira.yaml
@@ -17,12 +17,11 @@ jobs:
          !startsWith(github.event.pull_request.head.ref, 'revert-') }}
     runs-on: ubuntu-latest
     steps:
-      # Release 2.0.0
-      - uses: tzkhan/pr-update-action@bbd4c9395df8a9c4ef075b8b7fe29f2ca76cdca9
+      - uses: tzkhan/pr-update-action@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           head-branch-regex: '([A-Za-z]{2,4})-(\d{1,5})'
-          title-template: '%headbranch%: '
+          title-template: "%headbranch%: "
           title-update-action: prefix
           body-template: |
             Jira ticket: [%headbranch%](https://medibank.atlassian.net/browse/%headbranch%)

--- a/.github/workflows/validate-pr-conventions.yml
+++ b/.github/workflows/validate-pr-conventions.yml
@@ -66,8 +66,7 @@ jobs:
       DOCS_LINK: 'https://medibank.atlassian.net/wiki/spaces/AHM/pages/1969062105/Commits+-+Conventional+Commits'
     steps:
       - name: Checkout code
-        # Release 6.0.2
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Reverts ahmdigital/.github#41